### PR TITLE
Added NIOCompressor.resetStream()

### DIFF
--- a/Sources/CompressNIO/Compressor.swift
+++ b/Sources/CompressNIO/Compressor.swift
@@ -20,6 +20,9 @@ public protocol NIODecompressor: class {
     
     /// Finished using thie decompressor for stream decompression
     func finishStream() throws
+    
+    /// equivalent of calling `finishStream` followed by `startStream`.
+    func resetStream() throws
 }
 
 extension NIODecompressor {
@@ -28,6 +31,12 @@ extension NIODecompressor {
         try startStream()
         try streamInflate(from: &from, to: &to)
         try finishStream()
+    }
+
+    /// Default implementation of `reset`.
+    public func resetStream() throws {
+        try finishStream()
+        try startStream()
     }
 }
 
@@ -52,6 +61,9 @@ public protocol NIOCompressor: class {
     /// Finish using this compressor for stream compression
     func finishStream() throws
     
+    /// equivalent of calling `finishStream` followed by `startStream`. There maybe implementation of this that are more optimal
+    func resetStream() throws
+
     /// Return the maximum possible number of bytes required for the compressed version of a `ByteBuffer`
     /// - Parameter from: `ByteBuffer` to get maximum size for
     func maxSize(from: ByteBuffer) -> Int
@@ -63,6 +75,12 @@ extension NIOCompressor {
         try startStream()
         try streamDeflate(from: &from, to: &to, finalise: true)
         try finishStream()
+    }
+    
+    /// Default implementation of `reset`.
+    public func resetStream() throws {
+        try finishStream()
+        try startStream()
     }
 }
 

--- a/Sources/CompressNIO/Zlib.swift
+++ b/Sources/CompressNIO/Zlib.swift
@@ -119,6 +119,18 @@ class ZlibCompressor: NIOCompressor {
         let bufferSize = Int(CCompressZlib.deflateBound(&stream, UInt(from.readableBytes)))
         return bufferSize + 6
     }
+    
+    func resetStream() throws {
+        assert(isActive)
+        // deflateReset is a more optimal than calling finish and then start
+        let rt = deflateReset(&self.stream)
+        switch rt {
+        case Z_OK:
+            break
+        default:
+            throw CompressNIOError.internalError
+        }
+    }
 }
 
 /// Decompressor using Zlib
@@ -209,6 +221,18 @@ class ZlibDecompressor: NIODecompressor {
         switch rt {
         case Z_DATA_ERROR:
             throw CompressNIOError.unfinished
+        case Z_OK:
+            break
+        default:
+            throw CompressNIOError.internalError
+        }
+    }
+    
+    func resetStream() throws {
+        assert(isActive)
+        // inflateReset is a more optimal than calling finish and then start
+        let rt = inflateReset(&self.stream)
+        switch rt {
         case Z_OK:
             break
         default:

--- a/Sources/CompressNIO/lz4.swift
+++ b/Sources/CompressNIO/lz4.swift
@@ -57,12 +57,18 @@ class LZ4Compressor: NIOCompressor {
         self.dictionary = nil
     }
     
+    func resetStream() throws {
+        assert(self.stream != nil)
+        // LZ4_resetStream_fast is a more optimal than calling finish and then start
+        LZ4_resetStream_fast(stream)
+    }
+
     func maxSize(from: ByteBuffer) -> Int {
         let bufferSize = LZ4_compressBound(Int32(from.readableBytes))
         return Int(bufferSize)
     }
 
-    public func deflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
+    func deflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
         var bytesRead = 0
         var bytesWritten = 0
 
@@ -90,16 +96,16 @@ class LZ4Compressor: NIOCompressor {
 
 }
 
-public class LZ4Decompressor: NIODecompressor {
+class LZ4Decompressor: NIODecompressor {
     var stream: UnsafeMutablePointer<LZ4_streamDecode_t>?
     var lastByteBuffer: ByteBuffer?
     
-    public func startStream() throws {
+    func startStream() throws {
         assert(self.stream == nil)
         self.stream = LZ4_createStreamDecode()
     }
     
-    public func streamInflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
+    func streamInflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
         assert(self.stream != nil)
         var bytesRead = 0
         var bytesWritten = 0
@@ -130,7 +136,7 @@ public class LZ4Decompressor: NIODecompressor {
         lastByteBuffer = to
     }
     
-    public func finishStream() throws {
+    func finishStream() throws {
         assert(self.stream != nil)
         LZ4_freeStreamDecode(self.stream)
         self.stream = nil
@@ -138,7 +144,7 @@ public class LZ4Decompressor: NIODecompressor {
 
     }
     
-    public func inflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
+    func inflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
         var bytesRead = 0
         var bytesWritten = 0
 


### PR DESCRIPTION
A quick path for finishStream/initStream.
Zlib and LZ4 implementations call reset functions that don’t free and reallocate memory buffers required.