### PR TITLE
Expose ZlibCompressor/Decompressor

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -8,7 +8,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: swift:5.7
+      image: swift:latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macOS-latest
     steps: 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: SPM tests
       run: swift test --enable-code-coverage --parallel
     - name: Convert coverage files
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'swift:5.7'
-          - 'swift:5.8'
           - 'swift:5.9'
+          - 'swift:5.10'
+          - 'swift:6.0'
     container:
       image: ${{ matrix.image }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Test
       run: |
         swift --version

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "compress-nio",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13)],
     products: [
         .library(name: "CompressNIO", targets: ["CompressNIO"]),
     ],

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ var uncompressedBuffer = buffer.decompress(with: .gzip)
 These methods allocate a new `ByteBuffer` for you. The `decompress` method can allocate multiple `ByteBuffers` while it is uncompressing depending on how well compressed the original `ByteBuffer` is. It is preferable to know in advance the size of buffer you need and allocate it yourself just the once and use the following functions.
 ```swift
 let uncompressedSize = buffer.readableBytes
-let maxCompressedSize = CompressionAlgorithm.deflate.compressor.maxSize(from:buffer)
-var compressedBuffer = ByteBufferAllocator().buffer(capacity: maxCompressedSize)
+var compressedBuffer = ByteBufferAllocator().buffer(capacity: knownCompressedSize)
 try buffer.compress(to: &compressedBuffer, with: .deflate)
 var uncompressedBuffer = ByteBufferAllocator().buffer(capacity: uncompressedSize)
 try compressedBuffer.decompress(to: &uncompressedBuffer, with: .deflate)
 ```
-In the above example there is a call to a function `CompressionAlgorithm.deflate.compressor.maxSize(from:buffer)`. This returns the maximum size of buffer required to write out compressed data for the `deflate` compression algorithm.
+This returns the maximum size of buffer required to write out compressed data for the `deflate` compression algorithm.
 
 If you provide a buffer that is too small a `CompressNIO.bufferOverflow` error is thrown. You will need to provide a larger `ByteBuffer` to complete your operation.
 
@@ -31,29 +30,29 @@ There are three methods for doing stream compressing: window, allocating and raw
 #### Window method
 For the window method you provide a working buffer for the compressor to use. When you call `compressStream` it compresses into this buffer and when the buffer is full it will call a `process` closure you have provided.
 ```swift
-let compressor = CompressionAlgorithm.gzip.compressor
-compressor.window = ByteBufferAllocator().buffer(capacity: 64*1024)
-try compressor.startStream()
+let compressor = ZlibCompressor(algorithm: .gzip)
+var window = ByteBufferAllocator().buffer(capacity: 64*1024)
 while var buffer = getData() {
-    try buffer.compressStream(with: compressor, flush: .finish) { buffer in
+    try buffer.compressStream(with: compressor, window: window, flush: .finish) { buffer in
         // process your compressed data
     }
 }
-try compressor.finishStream()
+try compressor.reset()
 ```
 #### Allocation method
 With the allocating method you leave the compressor to allocate the ByteBuffers for output data. It will calculate the maximum possible size the compressed data could be and allocates that amount of space for each compressed data block. The last compressed block needs to have the `flush` parameter set to `.finish`
 ```swift
-let compressor = CompressionAlgorithm.gzip.compressor
-try compressor.startStream()
+let compressor = ZlibCompressor(algorithm: .gzip)
 while var buffer = getData() {
     let flush: CompressNIOFlush = isThisTheFinalBlock ? .finish : .sync
     let compressedBuffer = try buffer.compressStream(with: compressor, flush: flush, allocator: ByteBufferAllocator())
 }
-try compressor.finishStream()
+try compressor.reset()
 ```
-If you don't know when you are receiving your last data block you can always compress an empty `ByteBuffer` with the `flush` set to `.finish` to get your final block. Also note that the flush parameter is set to `.sync` in the loop. This is required otherwise the next `compressStream` cannot successfully estimate its buffer size as there might be buffered data still waiting to be output.
+If you don't know what is your final data block you can always compress an empty `ByteBuffer` with the `flush` set to `.finish` to get your final block. Also note that the flush parameter is set to `.sync` in the loop. This is required otherwise the next `compressStream` cannot successfully estimate its buffer size as there might be buffered data still waiting to be output.
+
 #### Raw method
+
 With this mehod you call the lowest level function and deal with `.bufferOverflow` errors thrown whenever you run out of space in your output buffer. You will need a loop for receiving data and then you will need an inner loop for compressing that data. You call the `compress` until you have no more data to compress. Everytime you receive a `.bufferOverflow` error you have to provide a new output data. Once you have read all the input data you do the same again but with the `flush` parameter set to `.finish`.
 
 ## Decompressing

--- a/Sources/CompressNIO/ByteBuffer+compress.swift
+++ b/Sources/CompressNIO/ByteBuffer+compress.swift
@@ -25,8 +25,9 @@ extension ByteBuffer {
         allocator: ByteBufferAllocator = ByteBufferAllocator()
     ) throws -> ByteBuffer {
         let compressor = algorithm.compressor
+        try compressor.startStream()
         var buffer = allocator.buffer(capacity: compressor.maxSize(from: self))
-        try compressor.deflate(from: &self, to: &buffer)
+        try compressor.streamDeflate(from: &self, to: &buffer, flush: .finish)
         return buffer
     }
 

--- a/Sources/CompressNIO/CompressionAlgorithm.swift
+++ b/Sources/CompressNIO/CompressionAlgorithm.swift
@@ -23,14 +23,12 @@ public struct CompressionAlgorithm: CustomStringConvertible, Sendable {
     /// - Parameter windowSize: Window size to use in compressor. Window size is 2^windowSize
     public var compressor: NIOCompressor {
         switch self.algorithm {
-        case .gzip(var configuration):
-            configuration.windowSize = 16 + configuration.windowSize
-            return ZlibCompressor(configuration: configuration)
+        case .gzip(let configuration):
+            return ZlibCompressorWrapper(configuration: configuration, algorithm: .gzip)
         case .zlib(let configuration):
-            return ZlibCompressor(configuration: configuration)
-        case .deflate(var configuration):
-            configuration.windowSize = -configuration.windowSize
-            return ZlibCompressor(configuration: configuration)
+            return ZlibCompressorWrapper(configuration: configuration, algorithm: .zlib)
+        case .deflate(let configuration):
+            return ZlibCompressorWrapper(configuration: configuration, algorithm: .deflate)
         }
     }
 
@@ -40,11 +38,11 @@ public struct CompressionAlgorithm: CustomStringConvertible, Sendable {
     public var decompressor: NIODecompressor {
         switch self.algorithm {
         case .gzip(let configuration):
-            return ZlibDecompressor(windowSize: 16 + configuration.windowSize)
+            return ZlibDecompressorWrapper(windowSize: configuration.windowSize, algorithm: .gzip)
         case .zlib(let configuration):
-            return ZlibDecompressor(windowSize: configuration.windowSize)
+            return ZlibDecompressorWrapper(windowSize: configuration.windowSize, algorithm: .zlib)
         case .deflate(let configuration):
-            return ZlibDecompressor(windowSize: -configuration.windowSize)
+            return ZlibDecompressorWrapper(windowSize: configuration.windowSize, algorithm: .deflate)
         }
     }
 

--- a/Sources/CompressNIO/Compressor.swift
+++ b/Sources/CompressNIO/Compressor.swift
@@ -102,4 +102,23 @@ extension NIOCompressor {
         try finishStream()
         try startStream()
     }
+
+    @available(*, deprecated, message: "This function isn't used anymore")
+    public func finishWindowedStream(process: (ByteBuffer)->()) throws {
+        guard var window = self.window else { preconditionFailure("finishWindowedStream requires your compressor has a window buffer") }
+        while true {
+            do {
+                try finishDeflate(to: &window)
+                break
+            } catch let error as CompressNIOError where error == .bufferOverflow {
+                process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            }
+        }
+
+        if window.readableBytes > 0 {
+            process(window)
+        }
+    }
 }

--- a/Sources/CompressNIO/Compressor.swift
+++ b/Sources/CompressNIO/Compressor.swift
@@ -8,22 +8,22 @@ public protocol NIODecompressor: AnyObject {
     ///   - from: source byte buffer
     ///   - to: destination byte buffer
     func inflate(from: inout ByteBuffer, to: inout ByteBuffer) throws
-    
+
     /// Working buffer for window based compression
     var window: ByteBuffer? { get set }
-    
+
     /// Setup decompressor for stream decompression
     func startStream() throws
-    
+
     /// Decompress block as part of a stream to another ByteBuffer
     /// - Parameters:
     ///   - from: source byte buffer
     ///   - to: destination byte buffer
     func streamInflate(from: inout ByteBuffer, to: inout ByteBuffer) throws
-    
+
     /// Finished using thie decompressor for stream decompression
     func finishStream() throws
-    
+
     /// equivalent of calling `finishStream` followed by `startStream`.
     func resetStream() throws
 }
@@ -60,13 +60,13 @@ public protocol NIOCompressor: AnyObject {
     ///   - from: source byte buffer
     ///   - to: destination byte buffer
     func deflate(from: inout ByteBuffer, to: inout ByteBuffer) throws
-    
+
     /// Working buffer for window based compression
     var window: ByteBuffer? { get set }
-    
+
     /// Setup compressor for stream compression
     func startStream() throws
-    
+
     /// Compress block as part of a stream compression
     /// - Parameters:
     ///   - from: source byte buffer
@@ -82,7 +82,7 @@ public protocol NIOCompressor: AnyObject {
     func finishStream() throws
 
     /// Finish using this compressor for stream compression
-    func finishWindowedStream(process: (ByteBuffer)->()) throws
+    func finishWindowedStream(process: (ByteBuffer) -> Void) throws
 
     /// equivalent of calling `finishStream` followed by `startStream`. There maybe implementation of this that are more optimal
     func resetStream() throws
@@ -99,14 +99,14 @@ extension NIOCompressor {
         try streamDeflate(from: &from, to: &to, flush: .finish)
         try finishStream()
     }
-    
+
     /// Default implementation of `reset`.
     public func resetStream() throws {
         try finishStream()
         try startStream()
     }
 
-    public func finishWindowedStream(process: (ByteBuffer)->()) throws {
+    public func finishWindowedStream(process: (ByteBuffer) -> Void) throws {
         guard var window = self.window else { preconditionFailure("finishWindowedStream requires your compressor has a window buffer") }
         while true {
             do {
@@ -124,4 +124,3 @@ extension NIOCompressor {
         }
     }
 }
-

--- a/Sources/CompressNIO/Error.swift
+++ b/Sources/CompressNIO/Error.swift
@@ -10,6 +10,7 @@ public struct CompressNIOError: Swift.Error, CustomStringConvertible, Equatable 
         case noMoreMemory
         case unfinished
         case internalError
+        case uninitializedStream
     }
 
     fileprivate let error: ErrorEnum
@@ -27,6 +28,8 @@ public struct CompressNIOError: Swift.Error, CustomStringConvertible, Equatable 
     public static let noMoreMemory = CompressNIOError(error: .noMoreMemory)
     /// called `streamFinish`while there is still data to process
     public static let unfinished = CompressNIOError(error: .unfinished)
+    /// called stream function while stream was unintialised
+    public static let uninitializedStream = CompressNIOError(error: .uninitializedStream)
     /// error internal to system
     public static let internalError = CompressNIOError(error: .internalError)
 }

--- a/Sources/CompressNIO/zlib/ByteBuffer+zlib+compress.swift
+++ b/Sources/CompressNIO/zlib/ByteBuffer+zlib+compress.swift
@@ -1,0 +1,218 @@
+
+import NIOCore
+
+// compress extensions to ByteBuffer
+extension ByteBuffer {
+    /// Compress the readable contents of this byte buffer into another using the compression algorithm specified
+    /// - Parameters:
+    ///   - buffer: Byte buffer to write compressed data to
+    ///   - algorithm: Algorithm to use when compressing
+    /// - Throws:
+    ///     - `NIOCompression.Error.bufferOverflow` if output byte buffer doesnt have enough space to
+    ///         write the compressed data into
+    public mutating func compress(to buffer: inout ByteBuffer, with algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init()) throws {
+        var compressor = ZlibCompressor(algorithm: algorithm, configuration: configuration)
+        try compressor.deflate(from: &self, to: &buffer)
+    }
+
+    /// Allocate a new byte buffer and compress this byte buffer into it using the compression algorithm specified
+    /// - Parameters:
+    ///   - algorithm: Algorithm to use when compressing
+    ///   - allocator: Byte buffer allocator used to create new byte buffer
+    /// - Returns: the new byte buffer with the compressed data
+    public mutating func compress(
+        with algorithm: ZlibAlgorithm,
+        configuration: ZlibConfiguration = .init(),
+        allocator: ByteBufferAllocator = ByteBufferAllocator()
+    ) throws -> ByteBuffer {
+        var compressor = ZlibCompressor(algorithm: algorithm, configuration: configuration)
+        var buffer = allocator.buffer(capacity: compressor.maxSize(from: self))
+        try compressor.deflate(from: &self, to: &buffer)
+        return buffer
+    }
+
+    /// A version of compressStream which you provide a fixed sized window buffer to and a process closure.
+    ///
+    /// When the window buffer is full the process closure is called. If there is any unprocessed data left
+    /// at the end of the compress the process closure is called with this.
+    ///
+    /// Before calling this you need to provide a working window `ByteBuffer` to the compressor by setting
+    /// `NIOCompressor.window`.
+    ///
+    /// - Parameters:
+    ///   - compressor: Algorithm to use when compressing
+    ///   - flush: how compressor should flush output data.
+    ///   - process: Closure to be called when window buffer fills up or compress has finished
+    /// - Returns: `ByteBuffer` containing compressed data
+    public mutating func compressStream(
+        with compressor: inout ZlibCompressor,
+        window: inout ByteBuffer,
+        flush: CompressNIOFlush,
+        process: (ByteBuffer) throws -> Void
+    ) throws {
+        while self.readableBytes > 0 {
+            do {
+                try self.compressStream(to: &window, with: &compressor, flush: .no)
+            } catch let error as CompressNIOError where error == .bufferOverflow {
+                try process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            }
+        }
+
+        if flush == .sync {
+            while true {
+                do {
+                    try self.compressStream(to: &window, with: &compressor, flush: .sync)
+                    break
+                } catch let error as CompressNIOError where error == .bufferOverflow {
+                    try process(window)
+                    window.moveReaderIndex(to: 0)
+                    window.moveWriterIndex(to: 0)
+                }
+            }
+        } else if flush == .finish {
+            while true {
+                do {
+                    try self.compressStream(to: &window, with: &compressor, flush: .finish)
+                    break
+                } catch let error as CompressNIOError where error == .bufferOverflow {
+                    try process(window)
+                    window.moveReaderIndex(to: 0)
+                    window.moveWriterIndex(to: 0)
+                }
+            }
+        }
+
+        if flush == .finish {
+            if window.readableBytes > 0 {
+                try process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            }
+        }
+    }
+
+    /// A version of compressStream which allocates the ByteBuffer to write into.
+    ///
+    /// If you call this after a call to another `compressStream` this cannot accurately calculate the size
+    /// of the buffer required to compress into unless the previous call to `compressStream` was called with
+    /// `flush` set to `.sync`. If the buffer calculation is inaccurate a `.bufferOverflow` error is thrown.
+    ///
+    /// - Parameters:
+    ///   - compressor: Algorithm to use when compressing
+    ///   - flush: how compressor should flush output data.
+    ///   - allocator: Byte buffer allocator used to allocate the new `ByteBuffer`
+    /// - Throws:
+    ///     - `NIOCompression.Error.bufferOverflow` if the allocated byte buffer doesn't have enough space to write the decompressed data into
+    /// - Returns: `ByteBuffer` containing compressed data
+    public mutating func compressStream(
+        with compressor: inout ZlibCompressor,
+        flush: CompressNIOFlush,
+        allocator: ByteBufferAllocator = ByteBufferAllocator()
+    ) throws -> ByteBuffer {
+        var byteBuffer = allocator.buffer(capacity: compressor.maxSize(from: self))
+        try self.compressStream(to: &byteBuffer, with: &compressor, flush: flush)
+        return byteBuffer
+    }
+
+    /// Compress one byte buffer from a stream of blocks into another bytebuffer
+    ///
+    /// The compress stream functions work with a stream of data. You create a `NIOCompressor`, call
+    /// `startStream` on it and then for each chunk of data in the stream you call `compressStream`.
+    /// Your last block should be called with the `flush` parameter set to `.finish`. Once you are complete
+    /// call `endStream`.
+    ///  eg
+    ///  ```
+    ///  let compressor = NIOCompression.Algorithm.gzip.compressor
+    ///  try compressor.startStream()
+    ///  try inputBuffer1.compressStream(to: &outputBuffer, with: compressor, flush: .no)
+    ///  try inputBuffer2.compressStream(to: &outputBuffer, with: compressor, flush: .no)
+    ///  ...
+    ///  try inputBufferN.compressStream(to: &outputBuffer, with: compressor, flush: .finish)
+    ///  try decompressor.finishStream()
+    ///  ````
+    ///
+    ///  If you call this function without `flush` set to `.finish` it will return if some data has been
+    /// processed. Unless you are certain you have provided a output buffer large enough you should to see
+    /// if your input buffer has any `readableBytes` left and call the function again if there are any.
+    /// If a `bufferOverflow` error is thrown you need to supply a larger buffer and call the `compressStream`
+    /// again. Remember though the `ByteBuffer` you were writing into from the original call could have some
+    /// decompressed data in it still so don't throw it away.
+    ///
+    /// - Parameters:
+    ///   - byteBuffer: byte buffer block from a large byte buffer
+    ///   - compressor: Algorithm to use when compressing
+    ///   - flush: how compressor should flush output data.
+    /// - Throws:
+    ///     - `NIOCompression.Error.bufferOverflow` if output byte buffer doesn't have enough space to write the compressed data into
+    public mutating func compressStream(
+        to byteBuffer: inout ByteBuffer,
+        with compressor: inout ZlibCompressor,
+        flush: CompressNIOFlush
+    ) throws {
+        try compressor.streamDeflate(from: &self, to: &byteBuffer, flush: flush)
+    }
+
+    /// A version of compressStream which you provide a fixed sized window buffer to and a process closure.
+    ///
+    /// When the window buffer is full the process closure is called. If there is any unprocessed data left
+    /// at the end of the compress the process closure is called with this.
+    ///
+    /// Before calling this you need to provide a working window `ByteBuffer` to the compressor by setting
+    /// `NIOCompressor.window`.
+    ///
+    /// - Parameters:
+    ///   - compressor: Algorithm to use when compressing
+    ///   - flush: how compressor should flush output data.
+    ///   - process: Closure to be called when window buffer fills up or compress has finished
+    /// - Returns: `ByteBuffer` containing compressed data
+    public mutating func compressStream(
+        with compressor: inout ZlibCompressor,
+        window: inout ByteBuffer,
+        flush: CompressNIOFlush,
+        process: (ByteBuffer) async throws -> Void
+    ) async throws {
+        while self.readableBytes > 0 {
+            do {
+                try self.compressStream(to: &window, with: &compressor, flush: .no)
+            } catch let error as CompressNIOError where error == .bufferOverflow {
+                try await process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            }
+        }
+
+        if flush == .sync {
+            while true {
+                do {
+                    try self.compressStream(to: &window, with: &compressor, flush: .sync)
+                    break
+                } catch let error as CompressNIOError where error == .bufferOverflow {
+                    try await process(window)
+                    window.moveReaderIndex(to: 0)
+                    window.moveWriterIndex(to: 0)
+                }
+            }
+        } else if flush == .finish {
+            while true {
+                do {
+                    try self.compressStream(to: &window, with: &compressor, flush: .finish)
+                    break
+                } catch let error as CompressNIOError where error == .bufferOverflow {
+                    try await process(window)
+                    window.moveReaderIndex(to: 0)
+                    window.moveWriterIndex(to: 0)
+                }
+            }
+        }
+
+        if flush == .finish {
+            if window.readableBytes > 0 {
+                try await process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            }
+        }
+    }
+}

--- a/Sources/CompressNIO/zlib/ByteBuffer+zlib+decompress.swift
+++ b/Sources/CompressNIO/zlib/ByteBuffer+zlib+decompress.swift
@@ -1,0 +1,219 @@
+
+import NIOCore
+
+// Decompress extensions to ByteBuffer
+extension ByteBuffer {
+    /// Decompress the readable contents of this byte buffer into another using the compression
+    /// algorithm specified.
+    ///
+    /// - Parameters:
+    ///   - buffer: Byte buffer to write decompressed data to
+    ///   - algorithm: Algorithm to use when decompressing
+    /// - Throws:
+    ///     - `NIOCompression.Error.bufferOverflow` if output byte buffer doesn't have enough space
+    ///         to write the decompressed data into
+    ///     - `NIOCompression.Error.corruptData` if the input byte buffer is corrupted
+    public mutating func decompress(
+        to buffer: inout ByteBuffer,
+        with algorithm: ZlibAlgorithm,
+        configuration: ZlibConfiguration = .init()
+    ) throws {
+        var decompressor = ZlibDecompressor(algorithm: algorithm, windowSize: configuration.windowSize)
+        try decompressor.inflate(from: &self, to: &buffer)
+    }
+
+    /// Allocate a `ByteBuffer` to decompress this buffer into. Decompress  the readable contents of
+    /// this byte buffer into the allocated buffer. If the allocated buffer is too small allocate more
+    /// space and continue the decompression.
+    ///
+    /// Seeing as this method cannot tell the size of the buffer required to allocate for decompression
+    /// it may allocate many `ByteBuffers` during the decompress process. It is always preferable to
+    /// know in advance the size of the decompressed buffer and to use `decompress(to:with:)`.
+    ///
+    /// - Parameters:
+    ///   - buffer: Byte buffer to write decompressed data to
+    ///   - maxSize: Maximum size of buffer to allocate to decompress into
+    ///   - allocator: Byte buffer allocator used to create new byte buffers
+    /// - Throws:
+    ///     - `NIOCompression.Error.bufferOverflow` if output byte buffer doesn't have enough space to write the decompressed data into
+    ///     - `NIOCompression.Error.corruptData` if the input byte buffer is corrupted
+    public mutating func decompress(
+        with algorithm: ZlibAlgorithm,
+        configuration: ZlibConfiguration = .init(),
+        maxSize: Int = .max,
+        allocator: ByteBufferAllocator = ByteBufferAllocator()
+    ) throws -> ByteBuffer {
+        var decompressor = ZlibDecompressor(algorithm: algorithm, windowSize: configuration.windowSize)
+        try decompressor.startStream()
+        let buffer = try decompressStream(with: &decompressor, maxSize: maxSize, allocator: allocator)
+        try decompressor.finishStream()
+        return buffer
+    }
+
+    /// A version of decompressStream which you provide a fixed sized window buffer to and a process closure.
+    ///
+    /// When the window buffer is full the process closure is called. If there is any unprocessed data left
+    /// at the end of the compress the process closure is called with this.
+    ///
+    /// Before calling this you need to provide a working window `ByteBuffer` to the decompressor by
+    /// setting `NIODecompressor.window`.
+    ///
+    /// - Parameters:
+    ///   - compressor: Algorithm to use when decompressing
+    ///   - process: Closure to be called when window buffer fills up or decompress has finished
+    /// - Returns: `ByteBuffer` containing compressed data
+    public mutating func decompressStream(
+        with decompressor: inout ZlibDecompressor,
+        window: inout ByteBuffer,
+        process: (ByteBuffer) throws -> Void
+    ) throws {
+        while self.readableBytes > 0 {
+            do {
+                try self.decompressStream(to: &window, with: &decompressor)
+            } catch let error as CompressNIOError where error == .bufferOverflow {
+                try process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            } catch let error as CompressNIOError where error == .inputBufferOverflow {
+                // can ignore CompressNIOError.inputBufferOverflow errors here
+            }
+        }
+
+        if window.readableBytes > 0 {
+            try process(window)
+        }
+    }
+
+    /// A version of decompressStream which allocates the ByteBuffer to write into.
+    ///
+    /// As with `decompress(with:allocator)` this method cannot tell the size of the buffer required to
+    /// allocate for the decompression. It may allocate many `ByteBuffers` during the decompress process.
+    /// It is always preferable to know in advance the size of the decompressed buffer and to use
+    /// `decompressStream(to:with:)`.
+    ///
+    /// - Parameters:
+    ///   - decompressor: Algorithm to use when decompressing
+    ///   - maxSize: Maximum size of buffer to allocate to decompress into
+    ///   - allocator: Byte buffer allocator used to allocate the new `ByteBuffer`
+    /// - Returns: `ByteBuffer` containing compressed data
+    public mutating func decompressStream(
+        with decompressor: inout ZlibDecompressor,
+        maxSize: Int = .max,
+        allocator: ByteBufferAllocator = ByteBufferAllocator()
+    ) throws -> ByteBuffer {
+        var buffers: [ByteBuffer] = []
+        let originalSize = self.readableBytes
+        func _decompress(iteration: Int, bufferSize: Int) throws {
+            var bufferSize = bufferSize
+            if bufferSize >= maxSize {
+                throw CompressNIOError.bufferOverflow
+            }
+            var nextBufferSize = iteration * 3 * originalSize / 2
+            if bufferSize + nextBufferSize > maxSize {
+                nextBufferSize = maxSize - bufferSize
+            }
+            bufferSize += nextBufferSize
+            // grow buffer to write into with each iteration
+            var buffer = allocator.buffer(capacity: nextBufferSize)
+            do {
+                defer {
+                    if buffer.readableBytes > 0 {
+                        buffers.append(buffer)
+                    }
+                }
+                try self.decompressStream(to: &buffer, with: &decompressor)
+            } catch let error as CompressNIOError where error == CompressNIOError.bufferOverflow {
+                try _decompress(iteration: iteration + 1, bufferSize: bufferSize)
+            } catch let error as CompressNIOError where error == .inputBufferOverflow {
+                // can ignore CompressNIOError.inputBufferOverflow errors here
+            }
+        }
+
+        try _decompress(iteration: 1, bufferSize: 0)
+
+        if buffers.count == 0 {
+            return allocator.buffer(capacity: 0)
+        } else if buffers.count == 1 {
+            return buffers[0]
+        } else {
+            // concatenate all the buffers together
+            let size = buffers.reduce(0) { return $0 + $1.readableBytes }
+            var finalBuffer = allocator.buffer(capacity: size)
+            for var buffer in buffers {
+                finalBuffer.writeBuffer(&buffer)
+            }
+            return finalBuffer
+        }
+    }
+
+    /// Decompress one byte buffer from a stream of blocks out of a compressed bytebuffer
+    ///
+    /// The decompress stream functions work with a stream of data. You create a `NIODecompressor`,
+    /// call `startStream` on it and then for each chunk of data in the stream you call `decompressStream`.
+    /// Once you are complete call `endStream`.
+    ///  eg
+    ///  ```
+    ///  let decompressor = NIOCompression.Algorithm.gzip.decompressor
+    ///  try decompressor.startStream()
+    ///  try inputBuffer1.decompressStream(to: &outputBuffer, with: decompressor)
+    ///  try inputBuffer2.decompressStream(to: &outputBuffer, with: decompressor)
+    ///  ...
+    ///  try decompressor.finishStream()
+    ///  ````
+    ///
+    ///  If a `bufferOverflow` error is thrown you can supply a larger buffer and call the `decompressStream`
+    /// again. Remember though the `ByteBuffer` you were writing into from the original call could have some
+    /// decompressed data in it still so don't throw it away.
+    ///
+    /// - Parameters:
+    ///   - byteBuffer: byte buffer block from a compressed buffer
+    ///   - decompressor: Algorithm to use when decompressing
+    /// - Throws:
+    ///     - `NIOCompression.Error.bufferOverflow` if output byte buffer doesn't have enough space to write
+    ///            the decompressed data into
+    ///     - `NIOCompression.Error.corruptData` if the input byte buffer is corrupted
+    public mutating func decompressStream(
+        to byteBuffer: inout ByteBuffer,
+        with decompressor: inout ZlibDecompressor
+    ) throws {
+        do {
+            try decompressor.streamInflate(from: &self, to: &byteBuffer)
+        } catch let error as CompressNIOError where error == .inputBufferOverflow {
+            // can ignore CompressNIOError.inputBufferOverflow errors here
+        }
+    }
+
+    /// A version of decompressStream which you provide a fixed sized window buffer to and a process closure.
+    ///
+    /// When the window buffer is full the process closure is called. If there is any unprocessed data left
+    /// at the end of the compress the process closure is called with this.
+    ///
+    /// Before calling this you need to provide a working window `ByteBuffer` to the decompressor by
+    /// setting `NIODecompressor.window`.
+    ///
+    /// - Parameters:
+    ///   - compressor: Algorithm to use when decompressing
+    ///   - process: Closure to be called when window buffer fills up or decompress has finished
+    /// - Returns: `ByteBuffer` containing compressed data
+    public mutating func decompressStream(
+        with decompressor: inout ZlibDecompressor,
+        window: inout ByteBuffer,
+        process: (ByteBuffer) async throws -> Void
+    ) async throws {
+        while self.readableBytes > 0 {
+            do {
+                try self.decompressStream(to: &window, with: &decompressor)
+            } catch let error as CompressNIOError where error == .bufferOverflow {
+                try await process(window)
+                window.moveReaderIndex(to: 0)
+                window.moveWriterIndex(to: 0)
+            } catch let error as CompressNIOError where error == .inputBufferOverflow {
+                // can ignore CompressNIOError.inputBufferOverflow errors here
+            }
+        }
+
+        if window.readableBytes > 0 {
+            try await process(window)
+        }
+    }
+}

--- a/Sources/CompressNIO/zlib/Zlib.swift
+++ b/Sources/CompressNIO/zlib/Zlib.swift
@@ -3,7 +3,7 @@ import CCompressZlib
 import NIOCore
 
 /// Zlib algorithm
-public enum ZlibAlgorithm {
+public enum ZlibAlgorithm: Sendable {
     case gzip
     case zlib
     case deflate

--- a/Sources/CompressNIO/zlib/Zlib.swift
+++ b/Sources/CompressNIO/zlib/Zlib.swift
@@ -72,12 +72,16 @@ public struct ZlibConfiguration: Sendable {
 }
 
 /// Compressor using Zlib
-public struct ZlibCompressor: ~Copyable {
-    let configuration: ZlibConfiguration
+public final class ZlibCompressor {
     var stream: z_stream
-    var isActive: Bool
 
-    public init(algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init()) {
+    /// Initialize Zlib deflate stream for compression
+    /// - Parameters:
+    ///   - algorithm: Zlib algorithm
+    ///   - configuration: Zlib configuration
+    ///
+    /// - Throws: ``CompressNIOError`` if deflate stream fails to initialize
+    public init(algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init()) throws {
         var configuration = configuration
         switch algorithm {
         case .gzip:
@@ -87,37 +91,19 @@ public struct ZlibCompressor: ~Copyable {
         case .deflate:
             configuration.windowSize = -configuration.windowSize
         }
-        self.configuration = configuration
-        self.isActive = false
 
         self.stream = z_stream()
-        self.stream.zalloc = nil
-        self.stream.zfree = nil
-        self.stream.opaque = nil
-    }
-
-    deinit {
-        if isActive {
-            var stream = self.stream
-            deflateEnd(&stream)
-        }
-    }
-
-    public mutating func startStream() throws {
-        assert(!self.isActive)
-
-        // zlib docs say: The application must initialize zalloc, zfree and opaque before calling the init function.
         self.stream.zalloc = nil
         self.stream.zfree = nil
         self.stream.opaque = nil
 
         let rt = CCompressZlib_deflateInit2(
             &self.stream,
-            self.configuration.compressionLevel,
+            configuration.compressionLevel,
             Z_DEFLATED,
-            self.configuration.windowSize,
-            self.configuration.memoryLevel,
-            self.configuration.strategy.zlibValue
+            configuration.windowSize,
+            configuration.memoryLevel,
+            configuration.strategy.zlibValue
         )
         switch rt {
         case Z_MEM_ERROR:
@@ -127,17 +113,20 @@ public struct ZlibCompressor: ~Copyable {
         default:
             throw CompressNIOError.internalError
         }
-        self.isActive = true
     }
 
-    public mutating func deflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
-        try self.startStream()
-        try self.streamDeflate(from: &from, to: &to, flush: .finish)
-        try self.finishStream()
+    deinit {
+        var stream = self.stream
+        deflateEnd(&stream)
     }
 
-    public mutating func streamDeflate(from: inout ByteBuffer, to: inout ByteBuffer, flush: CompressNIOFlush) throws {
-        assert(self.isActive)
+    ///  Deflate Zlib stream
+    /// - Parameters:
+    ///   - from: source bytebuffer
+    ///   - to: output bytebuffer
+    ///   - flush: whether deflate should flush the output
+    /// - Throws: ``CompressNIOError`` if deflate fails
+    public func deflate(from: inout ByteBuffer, to: inout ByteBuffer, flush: CompressNIOFlush) throws {
         var bytesRead = 0
         var bytesWritten = 0
 
@@ -184,53 +173,7 @@ public struct ZlibCompressor: ~Copyable {
         }
     }
 
-    public mutating func finishDeflate(to: inout ByteBuffer) throws {
-        assert(self.isActive)
-        var bytesWritten = 0
-
-        defer {
-            to.moveWriterIndex(forwardBy: bytesWritten)
-        }
-
-        try to.withUnsafeMutableWritableBytes { toBuffer in
-            self.stream.avail_in = 0
-            self.stream.next_in = nil
-            self.stream.avail_out = UInt32(toBuffer.count)
-            self.stream.next_out = CCompressZlib_voidPtr_to_BytefPtr(toBuffer.baseAddress!)
-
-            let rt = CCompressZlib.deflate(&self.stream, Z_FINISH)
-            bytesWritten = self.stream.next_out - CCompressZlib_voidPtr_to_BytefPtr(toBuffer.baseAddress!)
-            switch rt {
-            case Z_OK:
-                throw CompressNIOError.bufferOverflow
-            case Z_DATA_ERROR:
-                throw CompressNIOError.corruptData
-            case Z_BUF_ERROR:
-                throw CompressNIOError.bufferOverflow
-            case Z_MEM_ERROR:
-                throw CompressNIOError.noMoreMemory
-            case Z_STREAM_END:
-                break
-            default:
-                throw CompressNIOError.internalError
-            }
-        }
-    }
-
-    public mutating func finishStream() throws {
-        assert(self.isActive)
-        self.isActive = false
-
-        let rt = deflateEnd(&self.stream)
-        switch rt {
-        case Z_OK:
-            break
-        default:
-            throw CompressNIOError.internalError
-        }
-    }
-
-    public mutating func maxSize(from: ByteBuffer) -> Int {
+    public func maxSize(from: ByteBuffer) -> Int {
         // deflateBound() provides an upper limit on the number of bytes the input can
         // compress to. We add 5 bytes to handle the fact that Z_SYNC_FLUSH will append
         // an empty stored block that is 5 bytes long.
@@ -245,9 +188,9 @@ public struct ZlibCompressor: ~Copyable {
         return bufferSize + 6
     }
 
-    public mutating func resetStream() throws {
-        assert(self.isActive)
-        // deflateReset is a more optimal than calling finish and then start
+    /// Reset deflate stream
+    /// - Throws: ``CompressNIOError`` if reset fails
+    public func reset() throws {
         let rt = deflateReset(&self.stream)
         switch rt {
         case Z_OK:
@@ -259,12 +202,16 @@ public struct ZlibCompressor: ~Copyable {
 }
 
 /// Decompressor using Zlib
-public struct ZlibDecompressor: ~Copyable {
-    let windowSize: Int32
-    var isActive: Bool
-    var stream = z_stream()
+public final class ZlibDecompressor {
+    var stream: z_stream
 
-    public init(algorithm: ZlibAlgorithm, windowSize: Int32 = 15) {
+    /// Initialize Zlib inflate stream for decompression
+    /// - Parameters:
+    ///   - algorithm: Zlib algorithm
+    ///   - windowSize: Window size used to inflate stream 8...15
+    ///
+    /// - Throws: ``CompressNIOError`` if inflate stream fails to initialize
+    public init(algorithm: ZlibAlgorithm, windowSize: Int32 = 15) throws {
         var windowSize = windowSize
         switch algorithm {
         case .gzip:
@@ -275,20 +222,7 @@ public struct ZlibDecompressor: ~Copyable {
             windowSize = -windowSize
         }
 
-        self.windowSize = windowSize
-        self.isActive = false
-    }
-
-    deinit {
-        if isActive {
-            var stream = self.stream
-            inflateEnd(&stream)
-        }
-    }
-
-    public mutating func startStream() throws {
-        assert(!self.isActive)
-
+        self.stream = z_stream()
         // zlib docs say: The application must initialize zalloc, zfree and opaque before calling the init function.
         self.stream.zalloc = nil
         self.stream.zfree = nil
@@ -296,7 +230,7 @@ public struct ZlibDecompressor: ~Copyable {
         self.stream.avail_in = 0
         self.stream.next_in = nil
 
-        let rt = CCompressZlib_inflateInit2(&self.stream, self.windowSize)
+        let rt = CCompressZlib_inflateInit2(&self.stream, windowSize)
         switch rt {
         case Z_MEM_ERROR:
             throw CompressNIOError.noMoreMemory
@@ -305,17 +239,20 @@ public struct ZlibDecompressor: ~Copyable {
         default:
             throw CompressNIOError.internalError
         }
-        self.isActive = true
     }
 
-    public mutating func inflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
-        try self.startStream()
-        try self.streamInflate(from: &from, to: &to)
-        try self.finishStream()
+    deinit {
+        var stream = self.stream
+        inflateEnd(&stream)
     }
 
-    public mutating func streamInflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
-        assert(self.isActive)
+    /// Inflate Zlib stream
+    /// - Parameters:
+    ///   - from: source bytebuffer
+    ///   - to: output bytebuffer
+    ///
+    /// - Throws: ``CompressNIOError`` if inflate fails
+    public func inflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
         var bytesRead = 0
         var bytesWritten = 0
 
@@ -357,22 +294,9 @@ public struct ZlibDecompressor: ~Copyable {
         }
     }
 
-    public mutating func finishStream() throws {
-        assert(self.isActive)
-        self.isActive = false
-        let rt = inflateEnd(&self.stream)
-        switch rt {
-        case Z_DATA_ERROR:
-            throw CompressNIOError.unfinished
-        case Z_OK:
-            break
-        default:
-            throw CompressNIOError.internalError
-        }
-    }
-
-    public mutating func resetStream() throws {
-        assert(self.isActive)
+    /// Reset Zlib inflate stream 
+    /// - Throws: ``CompressNIOError`` if reset fails
+    public func reset() throws {
         // inflateReset is a more optimal than calling finish and then start
         let rt = inflateReset(&self.stream)
         switch rt {

--- a/Sources/CompressNIO/zlib/ZlibWrapper.swift
+++ b/Sources/CompressNIO/zlib/ZlibWrapper.swift
@@ -1,0 +1,69 @@
+
+import CCompressZlib
+import NIOCore
+
+/// Compressor using Zlib
+final class ZlibCompressorWrapper: NIOCompressor {
+    var zlibCompressor: ZlibCompressor
+
+    init(configuration: ZlibConfiguration, algorithm: ZlibAlgorithm) {
+        self.zlibCompressor = .init(algorithm: algorithm, configuration: configuration)
+        self.window = nil
+    }
+
+    var window: ByteBuffer?
+
+    func startStream() throws {
+        try self.zlibCompressor.startStream()
+    }
+
+    func streamDeflate(from: inout ByteBuffer, to: inout ByteBuffer, flush: CompressNIOFlush) throws {
+        try self.zlibCompressor.streamDeflate(from: &from, to: &to, flush: flush)
+    }
+
+    func finishDeflate(to: inout ByteBuffer) throws {
+        try self.zlibCompressor.finishDeflate(to: &to)
+    }
+
+    func finishStream() throws {
+        try self.zlibCompressor.finishStream()
+        self.window?.moveReaderIndex(to: 0)
+        self.window?.moveWriterIndex(to: 0)
+    }
+
+    func maxSize(from: ByteBuffer) -> Int {
+        self.zlibCompressor.maxSize(from: from)
+    }
+
+    func resetStream() throws {
+        try self.zlibCompressor.resetStream()
+    }
+}
+
+/// Decompressor using Zlib
+final class ZlibDecompressorWrapper: NIODecompressor {
+    var zlibDecompressor: ZlibDecompressor
+
+    init(windowSize: Int32, algorithm: ZlibAlgorithm) {
+        self.zlibDecompressor = .init(algorithm: algorithm, windowSize: windowSize)
+        self.window = nil
+    }
+
+    var window: ByteBuffer?
+
+    func startStream() throws {
+        try self.zlibDecompressor.startStream()
+    }
+
+    func streamInflate(from: inout ByteBuffer, to: inout ByteBuffer) throws {
+        try self.zlibDecompressor.streamInflate(from: &from, to: &to)
+    }
+
+    func finishStream() throws {
+        try self.zlibDecompressor.finishStream()
+    }
+
+    func resetStream() throws {
+        try self.zlibDecompressor.resetStream()
+    }
+}

--- a/Tests/CompressNIOTests/NIOCompressTests.swift
+++ b/Tests/CompressNIOTests/NIOCompressTests.swift
@@ -337,13 +337,13 @@ class CompressNIOTests: XCTestCase {
         let buffer = self.createRandomBuffer(size: 1024)
         var bufferToCompress = buffer
         let compressor = CompressionAlgorithm.gzip().compressor
+        try compressor.startStream()
         var outputBuffer = ByteBufferAllocator().buffer(capacity: compressor.maxSize(from: bufferToCompress))
         let buffer2 = self.createRandomBuffer(size: 1024)
         var bufferToCompress2 = buffer2
         let compressor2 = CompressionAlgorithm.gzip().compressor
-        var outputBuffer2 = ByteBufferAllocator().buffer(capacity: compressor2.maxSize(from: bufferToCompress2))
-        try compressor.startStream()
         try compressor2.startStream()
+        var outputBuffer2 = ByteBufferAllocator().buffer(capacity: compressor2.maxSize(from: bufferToCompress2))
         try bufferToCompress.compressStream(to: &outputBuffer, with: compressor, flush: .finish)
         try bufferToCompress2.compressStream(to: &outputBuffer2, with: compressor2, flush: .finish)
         try compressor.finishStream()

--- a/Tests/CompressNIOTests/ZlibCompressTests.swift
+++ b/Tests/CompressNIOTests/ZlibCompressTests.swift
@@ -2,7 +2,7 @@
 import NIOCore
 import XCTest
 
-class CompressNIOTests: XCTestCase {
+class CompressZlibTests: XCTestCase {
     // create consistent buffer of random values. Will always create the same given you supply the same z and w values
     // Random number generator from https://www.codeproject.com/Articles/25172/Simple-Random-Number-Generation
     func createConsistentRandomBuffer(_ w: UInt, _ z: UInt, size: Int, randomness: Int = 100) -> ByteBuffer {
@@ -44,7 +44,7 @@ class CompressNIOTests: XCTestCase {
         return buffer
     }
 
-    func testCompressDecompress(_ algorithm: CompressionAlgorithm, bufferSize: Int = 16000) throws {
+    func testCompressDecompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), bufferSize: Int = 16000) throws {
         let buffer = self.createRandomBuffer(size: bufferSize, randomness: 50)
         var bufferToCompress = buffer
         var compressedBuffer = try bufferToCompress.compress(with: algorithm, allocator: ByteBufferAllocator())
@@ -53,30 +53,30 @@ class CompressNIOTests: XCTestCase {
         XCTAssertEqual(buffer, uncompressedBuffer)
     }
 
-    func streamCompress(_ algorithm: CompressionAlgorithm, buffer: inout ByteBuffer, blockSize: Int = 1024) throws -> ByteBuffer {
+    func streamCompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), buffer: inout ByteBuffer, blockSize: Int = 1024) throws -> ByteBuffer {
         // compress
-        let compressor = algorithm.compressor
+        var compressor = ZlibCompressor(algorithm: algorithm, configuration: configuration)
         try compressor.startStream()
         var compressedBuffer = ByteBufferAllocator().buffer(capacity: buffer.readableBytes)
 
         while buffer.readableBytes > 0 {
             let size = min(blockSize, buffer.readableBytes)
             var slice = buffer.readSlice(length: size)!
-            var compressedSlice = try slice.compressStream(with: compressor, flush: .no)
+            var compressedSlice = try slice.compressStream(with: &compressor, flush: .no)
             compressedBuffer.writeBuffer(&compressedSlice)
             compressedSlice.discardReadBytes()
             buffer.discardReadBytes()
         }
         var emptyBuffer = ByteBufferAllocator().buffer(capacity: 0)
 //        var compressedEmptyBuffer = ByteBufferAllocator().buffer(capacity: 16000)
-        try emptyBuffer.compressStream(to: &compressedBuffer, with: compressor, flush: .finish)
+        try emptyBuffer.compressStream(to: &compressedBuffer, with: &compressor, flush: .finish)
 //        compressedBuffer.writeBuffer(&compressedEmptyBuffer)
         try compressor.finishStream()
         return compressedBuffer
     }
 
-    func streamBlockCompress(_ algorithm: CompressionAlgorithm, buffer: inout ByteBuffer, blockSize: Int = 1024) throws -> [ByteBuffer] {
-        let compressor = algorithm.compressor
+    func streamBlockCompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), buffer: inout ByteBuffer, blockSize: Int = 1024) throws -> [ByteBuffer] {
+        var compressor = ZlibCompressor(algorithm: algorithm, configuration: configuration)
         try compressor.startStream()
         var compressedBuffers: [ByteBuffer] = []
         let minBlockSize = blockSize / 2
@@ -87,28 +87,28 @@ class CompressNIOTests: XCTestCase {
             blockSize = max(blockSize, minBlockSize)
             let size = min(blockSize, buffer.readableBytes)
             var slice = buffer.readSlice(length: size)!
-            var compressedSlice = try slice.compressStream(with: compressor, flush: .sync)
+            var compressedSlice = try slice.compressStream(with: &compressor, flush: .sync)
             compressedBuffers.append(compressedSlice)
             compressedSlice.discardReadBytes()
             buffer.discardReadBytes()
         }
         var emptyBuffer = ByteBufferAllocator().buffer(capacity: 0)
-        let compressedEmptyBlock = try emptyBuffer.compressStream(with: compressor, flush: .finish)
+        let compressedEmptyBlock = try emptyBuffer.compressStream(with: &compressor, flush: .finish)
         compressedBuffers.append(compressedEmptyBlock)
         try compressor.finishStream()
 
         return compressedBuffers
     }
 
-    func streamDecompress(_ algorithm: CompressionAlgorithm, from: inout ByteBuffer, to: inout ByteBuffer, blockSize: Int = 1024) throws {
+    func streamDecompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), from: inout ByteBuffer, to: inout ByteBuffer, blockSize: Int = 1024) throws {
         // decompress
-        let decompressor = algorithm.decompressor
+        var decompressor = ZlibDecompressor(algorithm: algorithm, windowSize: configuration.windowSize)
         try decompressor.startStream()
         while from.readableBytes > 0 {
             let size = min(blockSize, from.readableBytes)
             var slice = from.readSlice(length: size)!
             var writeOutBuffer = ByteBufferAllocator().buffer(capacity: to.writableBytes)
-            try slice.decompressStream(to: &writeOutBuffer, with: decompressor)
+            try slice.decompressStream(to: &writeOutBuffer, with: &decompressor)
             to.writeBuffer(&writeOutBuffer)
             writeOutBuffer.discardReadBytes()
             from.discardReadBytes()
@@ -116,12 +116,12 @@ class CompressNIOTests: XCTestCase {
         try decompressor.finishStream()
     }
 
-    func streamBlockDecompress(_ algorithm: CompressionAlgorithm, from: [ByteBuffer], to: inout ByteBuffer) throws {
-        let decompressor = algorithm.decompressor
+    func streamBlockDecompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), from: [ByteBuffer], to: inout ByteBuffer) throws {
+        var decompressor = ZlibDecompressor(algorithm: algorithm, windowSize: configuration.windowSize)
         try decompressor.startStream()
         for var buffer in from {
             var writeOutBuffer = ByteBufferAllocator().buffer(capacity: to.writableBytes)
-            try buffer.decompressStream(to: &writeOutBuffer, with: decompressor)
+            try buffer.decompressStream(to: &writeOutBuffer, with: &decompressor)
             to.writeBuffer(&writeOutBuffer)
             writeOutBuffer.discardReadBytes()
             buffer.discardReadBytes()
@@ -129,7 +129,7 @@ class CompressNIOTests: XCTestCase {
         try decompressor.finishStream()
     }
 
-    func testStreamCompressDecompress(_ algorithm: CompressionAlgorithm, bufferSize: Int = 16384, blockSize: Int = 1024) throws {
+    func testStreamCompressDecompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), bufferSize: Int = 16384, blockSize: Int = 1024) throws {
         let byteBufferAllocator = ByteBufferAllocator()
         let buffer = self.createRandomBuffer(size: bufferSize, randomness: 50)
 
@@ -144,7 +144,7 @@ class CompressNIOTests: XCTestCase {
 
     /// testBlockStreamCompressDecompress is different from testStreamCompressDecompress as it decompresses the
     /// slice that were compressed while testStreamCompressDecompress decompresses on a arbitrary block size
-    func testBlockStreamCompressDecompress(_ algorithm: CompressionAlgorithm, bufferSize: Int = 16396, blockSize: Int = 1024) throws {
+    func testBlockStreamCompressDecompress(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), bufferSize: Int = 16396, blockSize: Int = 1024) throws {
         let byteBufferAllocator = ByteBufferAllocator()
         let buffer = self.createRandomBuffer(size: bufferSize, randomness: 50)
 
@@ -185,14 +185,13 @@ class CompressNIOTests: XCTestCase {
         XCTAssertEqual(buffer, uncompressedBuffer)
     }
 
-    func streamCompressWindow(_ algorithm: CompressionAlgorithm, inputBufferSize: Int, streamBufferSize: Int, windowSize: Int) throws {
+    func streamCompressWindow(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), inputBufferSize: Int, streamBufferSize: Int, windowSize: Int) throws {
         // compress
         let buffer = self.createRandomBuffer(size: inputBufferSize, randomness: 40)
-        let window = ByteBufferAllocator().buffer(capacity: windowSize)
+        var window = ByteBufferAllocator().buffer(capacity: windowSize)
         var bufferToCompress = buffer
 
-        let compressor = algorithm.compressor
-        compressor.window = window
+        var compressor = ZlibCompressor(algorithm: algorithm, configuration: configuration)
         try compressor.startStream()
         var compressedBuffer = ByteBufferAllocator().buffer(capacity: 0)
 
@@ -200,7 +199,7 @@ class CompressNIOTests: XCTestCase {
             let size = min(bufferToCompress.readableBytes, streamBufferSize)
             let flush: CompressNIOFlush = bufferToCompress.readableBytes - size == 0 ? .finish : .no
             var slice = bufferToCompress.readSlice(length: size)!
-            try slice.compressStream(with: compressor, flush: flush) { window in
+            try slice.compressStream(with: &compressor, window: &window, flush: flush) { window in
                 var window = window
                 compressedBuffer.writeBuffer(&window)
             }
@@ -213,23 +212,22 @@ class CompressNIOTests: XCTestCase {
         XCTAssertEqual(buffer, uncompressedBuffer)
     }
 
-    func streamDecompressWindow(_ algorithm: CompressionAlgorithm, inputBufferSize: Int, streamBufferSize: Int, windowSize: Int) throws {
+    func streamDecompressWindow(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration = .init(), inputBufferSize: Int, streamBufferSize: Int, windowSize: Int) throws {
         // compress
         let buffer = self.createRandomBuffer(size: inputBufferSize, randomness: 25)
-        let window = ByteBufferAllocator().buffer(capacity: windowSize)
+        var window = ByteBufferAllocator().buffer(capacity: windowSize)
         var bufferToCompress = buffer
 
         var compressedBuffer = try bufferToCompress.compress(with: algorithm)
 
         var uncompressedBuffer = ByteBufferAllocator().buffer(capacity: 0)
-        let decompressor = algorithm.decompressor
-        decompressor.window = window
+        var decompressor = ZlibDecompressor(algorithm: algorithm, windowSize: configuration.windowSize)
         try decompressor.startStream()
 
         while compressedBuffer.readableBytes > 0 {
             let size = min(compressedBuffer.readableBytes, streamBufferSize)
             var slice = compressedBuffer.readSlice(length: size)!
-            try slice.decompressStream(with: decompressor) { window in
+            try slice.decompressStream(with: &decompressor, window: &window) { window in
                 var window = window
                 uncompressedBuffer.writeBuffer(&window)
             }
@@ -240,79 +238,79 @@ class CompressNIOTests: XCTestCase {
         XCTAssertEqual(buffer, uncompressedBuffer)
     }
 
-    func testCompressionAlgorithm(_ algorithm: CompressionAlgorithm) throws {
+    func testCompressionAlgorithm(_ algorithm: ZlibAlgorithm, configuration: ZlibConfiguration) throws {
         let buffer = self.createRandomBuffer(size: 10240, randomness: 20)
         var buffer1 = buffer
-        let compressor = algorithm.compressor
+        var compressor = ZlibCompressor(algorithm: algorithm, configuration: configuration)
         try compressor.startStream()
-        var compressedBuffer = try buffer1.compressStream(with: compressor, flush: .finish)
+        var compressedBuffer = try buffer1.compressStream(with: &compressor, flush: .finish)
         try compressor.finishStream()
 
-        let decompressor = algorithm.decompressor
+        var decompressor = ZlibDecompressor(algorithm: algorithm, windowSize: configuration.windowSize)
         try decompressor.startStream()
-        let buffer2 = try compressedBuffer.decompressStream(with: decompressor)
+        let buffer2 = try compressedBuffer.decompressStream(with: &decompressor)
         try decompressor.finishStream()
 
         XCTAssertEqual(buffer, buffer2)
     }
 
     func testGZipCompressDecompress() throws {
-        try self.testCompressDecompress(.gzip())
+        try self.testCompressDecompress(.gzip)
     }
 
     func testZlibCompressDecompress() throws {
-        try self.testCompressDecompress(.zlib())
+        try self.testCompressDecompress(.zlib)
     }
 
     func testRawDeflateCompressDecompress() throws {
-        try self.testCompressDecompress(.deflate())
+        try self.testCompressDecompress(.deflate)
     }
 
     func testGZipStreamCompressDecompress() throws {
-        try self.testStreamCompressDecompress(.gzip())
+        try self.testStreamCompressDecompress(.gzip)
     }
 
     func testZlibStreamCompressDecompress() throws {
-        try self.testBlockStreamCompressDecompress(.zlib())
+        try self.testBlockStreamCompressDecompress(.zlib)
     }
 
     func testRawDeflateStreamCompressDecompress() throws {
-        try self.testBlockStreamCompressDecompress(.deflate())
+        try self.testBlockStreamCompressDecompress(.deflate)
     }
 
     func testGZipBlockStreamCompressDecompress() throws {
-        try self.testBlockStreamCompressDecompress(.gzip())
+        try self.testBlockStreamCompressDecompress(.gzip)
     }
 
     func testZlibBlockStreamCompressDecompress() throws {
-        try self.testStreamCompressDecompress(.zlib())
+        try self.testStreamCompressDecompress(.zlib)
     }
 
     func testRawDeflateBlockStreamCompressDecompress() throws {
-        try self.testStreamCompressDecompress(.deflate())
+        try self.testStreamCompressDecompress(.deflate)
     }
 
     func testCompressWithWindow() throws {
-        try self.streamCompressWindow(.deflate(), inputBufferSize: 240_000, streamBufferSize: 110_000, windowSize: 75000)
+        try self.streamCompressWindow(.deflate, inputBufferSize: 240_000, streamBufferSize: 110_000, windowSize: 75000)
     }
 
     func testDecompressWithWindow() throws {
-        try self.streamDecompressWindow(.gzip(), inputBufferSize: 256_000, streamBufferSize: 75000, windowSize: 32000)
+        try self.streamDecompressWindow(.gzip, inputBufferSize: 256_000, streamBufferSize: 75000, windowSize: 32000)
     }
 
     func testWindowSize() throws {
-        try self.testCompressionAlgorithm(.gzip(configuration: .init(windowSize: 9)))
-        try self.testCompressionAlgorithm(.deflate(configuration: .init(windowSize: 12)))
+        try self.testCompressionAlgorithm(.gzip, configuration: .init(windowSize: 9))
+        try self.testCompressionAlgorithm(.deflate, configuration: .init(windowSize: 12))
     }
 
     func testCompressionLevel() throws {
-        try self.testCompressionAlgorithm(.gzip(configuration: .init(compressionLevel: 4)))
-        try self.testCompressionAlgorithm(.deflate(configuration: .init(compressionLevel: 9)))
+        try self.testCompressionAlgorithm(.gzip, configuration: .init(compressionLevel: 4))
+        try self.testCompressionAlgorithm(.deflate, configuration: .init(compressionLevel: 9))
     }
 
     func testMemoryLevel() throws {
-        try self.testCompressionAlgorithm(.gzip(configuration: .init(memoryLevel: 2)))
-        try self.testCompressionAlgorithm(.deflate(configuration: .init(memoryLevel: 9)))
+        try self.testCompressionAlgorithm(.gzip, configuration: .init(memoryLevel: 2))
+        try self.testCompressionAlgorithm(.deflate, configuration: .init(memoryLevel: 9))
     }
 
     func testDecompressWithInputBufferError() throws {
@@ -323,29 +321,29 @@ class CompressNIOTests: XCTestCase {
         var buffer5 = ByteBuffer(bytes: [0xCA, 0x2F, 0x02, 0x0A, 0x2B, 0xF9, 0x7B, 0x2B, 0xE9, 0x40, 0xA4, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF])
         var buffer6 = ByteBuffer(bytes: [0x42, 0x91, 0x72, 0xCE, 0xC9, 0x07, 0x00, 0x00, 0x00, 0xFF, 0xFF])
 
-        let decompressor = CompressionAlgorithm.deflate().decompressor
+        var decompressor = ZlibDecompressor(algorithm: .deflate)
         try decompressor.startStream()
-        _ = try buffer1.decompressStream(with: decompressor, maxSize: 65536)
-        _ = try buffer2.decompressStream(with: decompressor, maxSize: 65536)
-        _ = try buffer3.decompressStream(with: decompressor, maxSize: 65536)
-        _ = try buffer4.decompressStream(with: decompressor, maxSize: 65536)
-        _ = try buffer5.decompressStream(with: decompressor, maxSize: 65536)
-        _ = try buffer6.decompressStream(with: decompressor, maxSize: 65536)
+        _ = try buffer1.decompressStream(with: &decompressor, maxSize: 65536)
+        _ = try buffer2.decompressStream(with: &decompressor, maxSize: 65536)
+        _ = try buffer3.decompressStream(with: &decompressor, maxSize: 65536)
+        _ = try buffer4.decompressStream(with: &decompressor, maxSize: 65536)
+        _ = try buffer5.decompressStream(with: &decompressor, maxSize: 65536)
+        _ = try buffer6.decompressStream(with: &decompressor, maxSize: 65536)
     }
 
     func testTwoStreamsInParallel() throws {
         let buffer = self.createRandomBuffer(size: 1024)
         var bufferToCompress = buffer
-        let compressor = CompressionAlgorithm.gzip().compressor
+        var compressor = ZlibCompressor(algorithm: .gzip)
         var outputBuffer = ByteBufferAllocator().buffer(capacity: compressor.maxSize(from: bufferToCompress))
         let buffer2 = self.createRandomBuffer(size: 1024)
         var bufferToCompress2 = buffer2
-        let compressor2 = CompressionAlgorithm.gzip().compressor
+        var compressor2 = ZlibCompressor(algorithm: .gzip)
         var outputBuffer2 = ByteBufferAllocator().buffer(capacity: compressor2.maxSize(from: bufferToCompress2))
         try compressor.startStream()
         try compressor2.startStream()
-        try bufferToCompress.compressStream(to: &outputBuffer, with: compressor, flush: .finish)
-        try bufferToCompress2.compressStream(to: &outputBuffer2, with: compressor2, flush: .finish)
+        try bufferToCompress.compressStream(to: &outputBuffer, with: &compressor, flush: .finish)
+        try bufferToCompress2.compressStream(to: &outputBuffer2, with: &compressor2, flush: .finish)
         try compressor.finishStream()
         try compressor2.finishStream()
         var uncompressedBuffer = ByteBufferAllocator().buffer(capacity: 1024)
@@ -359,9 +357,9 @@ class CompressNIOTests: XCTestCase {
     func testDecompressWithWrongAlgorithm() {
         var buffer = self.createRandomBuffer(size: 1024)
         do {
-            var compressedBuffer = try buffer.compress(with: .gzip())
+            var compressedBuffer = try buffer.compress(with: .gzip)
             var outputBuffer = ByteBufferAllocator().buffer(capacity: 1024)
-            try compressedBuffer.decompress(to: &outputBuffer, with: .deflate())
+            try compressedBuffer.decompress(to: &outputBuffer, with: .deflate)
             XCTFail("Shouldn't get here")
         } catch let error as CompressNIOError where error == CompressNIOError.corruptData {
         } catch {
@@ -373,7 +371,7 @@ class CompressNIOTests: XCTestCase {
         var buffer = self.createRandomBuffer(size: 1024)
         var outputBuffer = ByteBufferAllocator().buffer(capacity: 16)
         do {
-            try buffer.compress(to: &outputBuffer, with: .gzip())
+            try buffer.compress(to: &outputBuffer, with: .gzip)
             XCTFail("Shouldn't get here")
         } catch let error as CompressNIOError where error == CompressNIOError.bufferOverflow {
         } catch {
@@ -385,9 +383,9 @@ class CompressNIOTests: XCTestCase {
         var buffer = self.createRandomBuffer(size: 1024)
         var outputBuffer = ByteBufferAllocator().buffer(capacity: 16)
         do {
-            let compressor = CompressionAlgorithm.gzip().compressor
+            var compressor = ZlibCompressor(algorithm: .gzip)
             try compressor.startStream()
-            try buffer.compressStream(to: &outputBuffer, with: compressor, flush: .finish)
+            try buffer.compressStream(to: &outputBuffer, with: &compressor, flush: .finish)
             XCTFail("Shouldn't get here")
         } catch let error as CompressNIOError where error == CompressNIOError.bufferOverflow {
         } catch {
@@ -398,15 +396,15 @@ class CompressNIOTests: XCTestCase {
     func testRetryCompressAfterOverflowError() throws {
         let buffer = self.createConsistentRandomBuffer(444, 10659, size: 5041, randomness: 34)
         var bufferToCompress = buffer
-        let compressor = CompressionAlgorithm.deflate().compressor
+        var compressor = ZlibCompressor(algorithm: .deflate)
         try compressor.startStream()
         var compressedBuffer = ByteBufferAllocator().buffer(capacity: 2048)
         do {
-            try bufferToCompress.compressStream(to: &compressedBuffer, with: compressor, flush: .finish)
+            try bufferToCompress.compressStream(to: &compressedBuffer, with: &compressor, flush: .finish)
             XCTFail("Shouldn't get here")
         } catch let error as CompressNIOError where error == CompressNIOError.bufferOverflow {
             var compressedBuffer2 = ByteBufferAllocator().buffer(capacity: 2048)
-            try bufferToCompress.compressStream(to: &compressedBuffer2, with: compressor, flush: .finish)
+            try bufferToCompress.compressStream(to: &compressedBuffer2, with: &compressor, flush: .finish)
             try compressor.finishStream()
             compressedBuffer.writeBuffer(&compressedBuffer2)
             var outputBuffer = ByteBufferAllocator().buffer(capacity: 5041)
@@ -419,10 +417,10 @@ class CompressNIOTests: XCTestCase {
         // create buffer that compresses to exactly 4096 bytes
         let buffer = self.createConsistentRandomBuffer(444, 10659, size: 5041, randomness: 34)
         var bufferToCompress = buffer
-        let compressor = CompressionAlgorithm.deflate().compressor
+        var compressor = ZlibCompressor(algorithm: .deflate)
         try compressor.startStream()
         var compressedBuffer = ByteBufferAllocator().buffer(capacity: 4096)
-        try bufferToCompress.compressStream(to: &compressedBuffer, with: compressor, flush: .finish)
+        try bufferToCompress.compressStream(to: &compressedBuffer, with: &compressor, flush: .finish)
     }
 
     func testDecompressWithOverflowError() {
@@ -442,15 +440,15 @@ class CompressNIOTests: XCTestCase {
         let buffer = self.createRandomBuffer(size: 1024)
         var bufferToCompress = buffer
         var compressedBuffer = try bufferToCompress.compress(with: .gzip())
-        let decompressor = CompressionAlgorithm.gzip().decompressor
+        var decompressor = ZlibDecompressor(algorithm: .gzip)
         try decompressor.startStream()
         var outputBuffer = ByteBufferAllocator().buffer(capacity: 512)
         do {
-            try compressedBuffer.decompressStream(to: &outputBuffer, with: decompressor)
+            try compressedBuffer.decompressStream(to: &outputBuffer, with: &decompressor)
             XCTFail("Shouldn't get here")
         } catch let error as CompressNIOError where error == CompressNIOError.bufferOverflow {
             var outputBuffer2 = ByteBufferAllocator().buffer(capacity: 1024)
-            try compressedBuffer.decompressStream(to: &outputBuffer2, with: decompressor)
+            try compressedBuffer.decompressStream(to: &outputBuffer2, with: &decompressor)
             outputBuffer.writeBuffer(&outputBuffer2)
             XCTAssertEqual(outputBuffer, buffer)
         }


### PR DESCRIPTION
This PR 
- [x] Makes ZlibCompressor/Decompressor non-copyable types (They hold mutable buffers generated by a C library). Doing this allows us to tag them as Sendable. 
- [x] Makes ZlibCompressor/Decompressor public
- [x] Adds ByteBuffer methods that use the ZlibCompressor/Decompressor directly
- [x] Add wrapper types that wrap the new types and conform to NIOCompressor/Decompressor to ensure we using the same code path whether we use NIO or Zlib types. 
- [x] Add tests that use new concrete types. 
- [ ] Deprecate NIOCompressor/Decompressor and related functions in favour of the Zlib versions. The NIO prefixed versions are unnecessary existentials and it is preferable to use the concrete Zlib versions. 